### PR TITLE
Expand repository tracking from 12 to 34 repositories

### DIFF
--- a/hub/README-REPO-CHANGES.md
+++ b/hub/README-REPO-CHANGES.md
@@ -1,0 +1,85 @@
+# Repository Configuration Changes
+
+## Overview
+
+The ModelEarth GitHub issues system has been expanded to include additional repositories for comprehensive issue tracking.
+
+## Changes Made
+
+### 1. Repository List Expansion
+
+**Original repositories (12):** 
+- modelearth, localsite, realitystream, feed, swiper, comparison, codechat, home, cloud, projects, browser-extension, embed
+
+**Removed repositories (2):**
+- browser-extension, embed
+
+**Additional repositories added (23):**
+- team - Rust REST API for Azure
+- MaterialScience - MaterialScience webroot  
+- products - Products frontend and python
+- products-data - Products data output
+- profile - Profile frontend analysis
+- exiobase - Trade flow output to .csv and SQL
+- io - Input-output analysis
+- useeio.js - JavaScript footprint tools (updated name: USEEIO.JS)
+- useeio-widgets - USEEIO React widgets
+- useeio-widgets-without-react - USEEIO widgets without React
+- useeiopy - Python USEEIO library
+- useeio_api - USEEIO REST API
+- useeio - Core USEEIO model
+- useeior - R package for USEEIO
+- useeio-state - State-level USEEIO data
+- useeio-json - USEEIO JSON data
+- mario - Multi-regional input-output
+- webroot - PartnerTools webroot
+- data-pipeline - Python data processing pipeline
+- community-data - Community-level data outputs
+- community-timelines - Timeline data for communities
+- community-zipcodes - ZIP code level community data
+- community-forecasting - Forecasting frontend
+- dataflow - Data flow NextJS UX
+
+**Total repositories now: 33**
+
+### 2. Files Modified
+
+- `repos.csv` - Updated with additional repositories
+- `js/issues.js` - Updated hardcoded fallback list to match CSV
+
+## Impact
+
+- **Issue Tracking**: Now tracks issues from 33 repositories instead of 12
+- **Dropdown Menu**: Repository filter now shows all 33 repositories with issue counts
+- **API Efficiency**: System will cache issue data for all repositories
+- **Fallback Safety**: Even if CSV fails to load, all repositories are included in hardcoded fallback
+- **USEEIO Ecosystem**: Comprehensive coverage of all USEEIO-related repositories (9 repos)
+- **Community Data**: Full tracking of community-level data and analysis tools (4 repos)
+
+## Technical Details
+
+### CSV Structure
+Each repository entry contains:
+- `repo_name` - GitHub repository name
+- `display_name` - Human-readable name for UI
+- `description` - Brief description of repository purpose
+- `default_branch` - Main branch (usually 'main', 'master', or 'dev')
+
+### Loading Process
+1. System attempts to load `repos.csv`
+2. If CSV fails, uses hardcoded fallback list in `issues.js`
+3. If GitHub token available, may also load additional repositories via API
+
+### Compatibility
+- Maintains backward compatibility
+- No breaking changes to existing functionality
+
+## Maintenance
+
+To add more repositories in the future:
+1. Edit `repos.csv` to add new entries
+2. Update hardcoded fallback list in `issues.js`
+
+To remove repositories:
+1. Remove entries from `repos.csv`
+2. Update hardcoded fallback list in `issues.js`

--- a/hub/repos.csv
+++ b/hub/repos.csv
@@ -9,5 +9,27 @@ codechat,CodeChat,Code chat interface,main
 home,Home,Home page content,main
 cloud,Cloud,Cloud platform tools,main
 projects,Projects,Project showcases,main
-browser-extension,Browser Extension,AnythingLLM Browser Extension,main
-embed,Embed,AnythingLLM Embed Widget,main
+team,Team,Rust REST API for Azure,main
+MaterialScience,MaterialScience,MaterialScience webroot,main
+products,Products,Products frontend and python,main
+products-data,Products Data,Products data output,main
+profile,Profile,Profile frontend analysis,main
+exiobase,Exiobase,Trade flow output to .csv and SQL,main
+io,IO,Input-output analysis,main
+useeio.js,USEEIO.JS,JavaScript footprint tools,dev
+useeio-widgets,USEEIO Widgets,USEEIO React widgets,master
+useeio-widgets-without-react,USEEIO Widgets Without React,USEEIO widgets without React,master
+useeiopy,USEEIO Python,Python USEEIO library,master
+useeio_api,USEEIO API,USEEIO REST API,master
+useeio,USEEIO Core,Core USEEIO model,master
+useeior,USEEIO R,R package for USEEIO,master
+useeio-state,USEEIO State,State-level USEEIO data,main
+useeio-json,USEEIO JSON,USEEIO JSON data,main
+mario,Mario,Multi-regional input-output,main
+webroot,Webroot,PartnerTools webroot,main
+data-pipeline,Data Pipeline,Python data processing pipeline,main
+community-data,Community data,Community-level data outputs,master
+community-timelines,Community Timeline,Timeline data for communities,main
+community-zipcodes,Community Zipcodes,ZIP code level community data,main
+community-forecasting,Community Forecasting,Forecasting frontend,main
+dataflow,Data flow,Data flow NextJS UX,main

--- a/js/issues.js
+++ b/js/issues.js
@@ -488,7 +488,7 @@ class GitHubIssuesManager {
             return parsed;
         } catch (error) {
             console.error('Error loading repositories from CSV:', error);
-            // Fallback to hardcoded list
+            // Fallback to hardcoded list (updated with additional repositories)
             return [
                 {repo_name: 'modelearth', display_name: 'ModelEarth', description: 'Main ModelEarth repository', default_branch: 'master'},
                 {repo_name: 'localsite', display_name: 'LocalSite', description: 'Core CSS/JS utilities', default_branch: 'main'},
@@ -500,6 +500,30 @@ class GitHubIssuesManager {
                 {repo_name: 'home', display_name: 'Home', description: 'Home page content', default_branch: 'main'},
                 {repo_name: 'cloud', display_name: 'Cloud', description: 'Cloud platform tools', default_branch: 'main'},
                 {repo_name: 'projects', display_name: 'Projects', description: 'Project showcases', default_branch: 'main'},
+                {repo_name: 'team', display_name: 'Team', description: 'Rust REST API for Azure', default_branch: 'main'},
+                {repo_name: 'MaterialScience', display_name: 'MaterialScience', description: 'MaterialScience webroot', default_branch: 'main'},
+                {repo_name: 'products', display_name: 'Products', description: 'Products frontend and python', default_branch: 'main'},
+                {repo_name: 'products-data', display_name: 'Products Data', description: 'Products data output', default_branch: 'main'},
+                {repo_name: 'profile', display_name: 'Profile', description: 'Profile frontend analysis', default_branch: 'main'},
+                {repo_name: 'exiobase', display_name: 'Exiobase', description: 'Trade flow output to .csv and SQL', default_branch: 'main'},
+                {repo_name: 'io', display_name: 'IO', description: 'Input-output analysis', default_branch: 'main'},
+                {repo_name: 'useeio.js', display_name: 'USEEIO.JS', description: 'JavaScript footprint tools', default_branch: 'dev'},
+                {repo_name: 'useeio-widgets', display_name: 'USEEIO Widgets', description: 'USEEIO React widgets', default_branch: 'master'},
+                {repo_name: 'useeio-widgets-without-react', display_name: 'USEEIO Widgets Without React', description: 'USEEIO widgets without React', default_branch: 'master'},
+                {repo_name: 'useeiopy', display_name: 'USEEIO Python', description: 'Python USEEIO library', default_branch: 'master'},
+                {repo_name: 'useeio_api', display_name: 'USEEIO API', description: 'USEEIO REST API', default_branch: 'master'},
+                {repo_name: 'useeio', display_name: 'USEEIO Core', description: 'Core USEEIO model', default_branch: 'master'},
+                {repo_name: 'useeior', display_name: 'USEEIO R', description: 'R package for USEEIO', default_branch: 'master'},
+                {repo_name: 'useeio-state', display_name: 'USEEIO State', description: 'State-level USEEIO data', default_branch: 'main'},
+                {repo_name: 'useeio-json', display_name: 'USEEIO JSON', description: 'USEEIO JSON data', default_branch: 'main'},
+                {repo_name: 'mario', display_name: 'Mario', description: 'Multi-regional input-output', default_branch: 'main'},
+                {repo_name: 'webroot', display_name: 'Webroot', description: 'PartnerTools webroot', default_branch: 'main'},
+                {repo_name: 'data-pipeline', display_name: 'Data Pipeline', description: 'Python data processing pipeline', default_branch: 'main'},
+                {repo_name: 'community-data', display_name: 'Community data', description: 'Community-level data outputs', default_branch: 'master'},
+                {repo_name: 'community-timelines', display_name: 'Community Timeline', description: 'Timeline data for communities', default_branch: 'main'},
+                {repo_name: 'community-zipcodes', display_name: 'Community Zipcodes', description: 'ZIP code level community data', default_branch: 'main'},
+                {repo_name: 'community-forecasting', display_name: 'Community Forecasting', description: 'Forecasting frontend', default_branch: 'main'},
+                {repo_name: 'dataflow', display_name: 'Data flow', description: 'Data flow NextJS UX', default_branch: 'main'},
             ];
         }
     }


### PR DESCRIPTION
- Update repos.csv with 23 additional repositories including USEEIO ecosystem and community tools
- Remove browser-extension and embed repositories
- Update hardcoded fallback list in issues.js to match CSV
- Add documentation explaining the repository expansion

Changes cover comprehensive ModelEarth ecosystem tracking including:
- USEEIO tools (9 repositories)
- Community data analysis (4 repositories)
- Development and analysis tools (10 repositories)


Here is the link to see the changes: https://shashank11yadav.github.io/projects/