### PR TITLE
Documentation and Debugging Notes for Issue #59 (BlueSky image fetch)

### DIFF
--- a/docs/blue-sky-image-notes.md
+++ b/docs/blue-sky-image-notes.md
@@ -1,0 +1,27 @@
+# Notes on BlueSky Image Fetch Issue (Issue #59)
+
+### Summary
+Images from linked websites in the BlueSky feed are currently not visible in the 
+ModelEarth interface. This appears to be related to the Rust CORS passthrough not 
+returning image data correctly.
+
+### Current Behavior
+- BlueSky feed loads text content correctly.
+- Image URLs appear in the data but images do not display.
+- Heroku-based service shows images, but local Rust API does not.
+
+### Possible Causes
+- CORS headers missing or blocked
+- Rust server not forwarding image blobs
+- Fetch requests failing silently
+- JS not receiving image content
+
+### Debugging Notes
+`console.log("Fetching BlueSky image:", imageUrl);` confirms the correct URLs 
+are being requested.
+
+### Next Steps
+- Check Rust server logs
+- Compare Heroku vs Local server responses
+- Review CORS configuration
+


### PR DESCRIPTION
This PR adds documentation and initial debugging notes related to Issue #59 
(Images from linked websites in the BlueSky feed not appearing).

Changes included:
- Added a new file: docs/blue-sky-image-notes.md
  * Summary of current behavior
  * Possible causes for images not loading
  * Debugging notes
  * Next steps and investigation plan

This helps clarify the issue for contributors and supports future fixes 
in the Rust CORS passthrough and image-loading process.
