### PR TITLE
feat: HTML+JS interactive trade charts for Exiobase homepage (Issue #65)

### DIFF
--- a/exiobase/README.md
+++ b/exiobase/README.md
@@ -1,0 +1,41 @@
+# Exiobase – Interactive Trade Charts
+
+Standalone HTML page that renders three interactive trade-flow visualisations
+for the [Exiobase.eu](https://www.exiobase.eu) homepage, addressing
+[Issue #65](https://github.com/ModelEarth/projects/issues/65).
+
+## Charts included
+
+| # | Chart | Library | What it shows |
+|---|-------|---------|---------------|
+| 1 | **Trade Flow Map** | Chart.js (bubble) | Total bilateral trade volume per country plotted on an approximate geographic grid. Bubble size scales with trade volume. |
+| 2 | **Chord Diagram** | D3.js | Country-to-country trade dependencies. Arc width encodes each country's share of total bilateral trade; ribbon width encodes the bilateral flow between any two countries. |
+| 3 | **Sankey Diagram** | Chart.js + chartjs-chart-sankey | Major trade flows as flow-volume ribbons between economies. |
+
+## Data
+
+The page uses **mock Exiobase-inspired data** (USD billion) so it runs entirely
+client-side without any backend or API key. Replace the `MATRIX`, `TRADE_VOLUME`,
+and `flows` arrays in `index.html` with real Exiobase API responses to go live.
+
+## Usage
+
+Open `index.html` directly in a browser, or serve it from any static host:
+
+```bash
+# quick local server (Python 3)
+python3 -m http.server 8080
+# then visit http://localhost:8080/exiobase/
+```
+
+## Styling
+
+The page loads `notion.css` from
+`https://model.earth/localsite/css/styles/notion.css` and applies
+`<body class="notion">` to match the rest of the model.earth design system.
+
+## Dependencies (CDN, no install needed)
+
+- [Chart.js 4](https://www.chartjs.org/)
+- [chartjs-chart-sankey](https://github.com/kurkle/chartjs-chart-sankey)
+- [D3.js 7](https://d3js.org/)

--- a/exiobase/README.md
+++ b/exiobase/README.md
@@ -1,41 +1,64 @@
 # Exiobase – Interactive Trade Charts
 
-Standalone HTML page that renders three interactive trade-flow visualisations
-for the [Exiobase.eu](https://www.exiobase.eu) homepage, addressing
+Standalone showcase page for the three interactive trade-flow charts on the
+[Exiobase.eu](https://www.exiobase.eu) homepage, addressing
 [Issue #65](https://github.com/ModelEarth/projects/issues/65).
 
-## Charts included
+## Charts
 
-| # | Chart | Library | What it shows |
-|---|-------|---------|---------------|
-| 1 | **Trade Flow Map** | Chart.js (bubble) | Total bilateral trade volume per country plotted on an approximate geographic grid. Bubble size scales with trade volume. |
-| 2 | **Chord Diagram** | D3.js | Country-to-country trade dependencies. Arc width encodes each country's share of total bilateral trade; ribbon width encodes the bilateral flow between any two countries. |
-| 3 | **Sankey Diagram** | Chart.js + chartjs-chart-sankey | Major trade flows as flow-volume ribbons between economies. |
+| # | Chart | Library | Data |
+|---|-------|---------|------|
+| 1 | **Trade Flow Map** | Leaflet 1.9 + D3 SVG overlay | Mock bilateral country matrix (M EUR) |
+| 2 | **Chord Diagram** | D3.js v7 | Mock bilateral country matrix |
+| 3 | **Sankey Diagram** | Apache eCharts 5.4.3 | **Live** `trade_impact.csv` from [ModelEarth/trade-data](https://github.com/ModelEarth/trade-data) |
 
-## Data
+### Trade Flow Map
+Renders a CartoDB light-basemap via Leaflet.  
+Country bubbles are sized by total bilateral trade. Animated curved arrows show
+the top-12 country pairs by volume. Matches the tech stack of
+`profile/trade/map/index.html`.
 
-The page uses **mock Exiobase-inspired data** (USD billion) so it runs entirely
-client-side without any backend or API key. Replace the `MATRIX`, `TRADE_VOLUME`,
-and `flows` arrays in `index.html` with real Exiobase API responses to go live.
+### Chord Diagram
+D3 chord layout showing 8 major economies.  
+Arc width = total export share; ribbon width = bilateral trade between two countries.
 
-## Usage
-
-Open `index.html` directly in a browser, or serve it from any static host:
-
-```bash
-# quick local server (Python 3)
-python3 -m http.server 8080
-# then visit http://localhost:8080/exiobase/
+### Sankey Diagram
+Uses Apache eCharts (same library as `io/charts/sankey/desktop/index.html`).  
+On load, fetches the **live** CSV:
 ```
+https://raw.githubusercontent.com/ModelEarth/trade-data/main/year/2022/WM/domestic/trade_impact.csv
+```
+Falls back to a mock country-level Sankey if the fetch fails.
+
+**Metric toggle** (controls bar): switch between Trade Amount, CO₂ Emissions,
+Water Use, and Employment.
 
 ## Styling
 
-The page loads `notion.css` from
-`https://model.earth/localsite/css/styles/notion.css` and applies
-`<body class="notion">` to match the rest of the model.earth design system.
+- `<body class="notion">` is included as specified in the issue
+- `notion.css` is not yet deployed to `localsite`; inline notion-inspired styles
+  serve as the fallback so the page renders correctly today
+- Colours and typography match the model.earth design system
 
-## Dependencies (CDN, no install needed)
+## Usage
 
-- [Chart.js 4](https://www.chartjs.org/)
-- [chartjs-chart-sankey](https://github.com/kurkle/chartjs-chart-sankey)
-- [D3.js 7](https://d3js.org/)
+```bash
+# From the repo webroot
+python3 -m http.server 8887
+# Visit: http://localhost:8887/exiobase/
+```
+
+## Dependencies (CDN — no build step)
+
+| Library | Version | Used for |
+|---------|---------|----------|
+| Leaflet | 1.9.4 | Trade Flow Map basemap |
+| D3.js | 7.8.5 | Chord diagram + map SVG overlay |
+| Apache eCharts | 5.4.3 | Sankey diagram |
+
+## Related pages
+
+- Trade Flow Map prototype: `model.earth/profile/trade/map/`
+- Chord Diagram (placeholder): `model.earth/profile/charts/d3/chord-diagram/`
+- Sankey (eCharts): `model.earth/io/charts/sankey/`
+- Trade data repo: [ModelEarth/trade-data](https://github.com/ModelEarth/trade-data)

--- a/exiobase/index.html
+++ b/exiobase/index.html
@@ -1,0 +1,368 @@
+<!DOCTYPE html>
+<html lang="en-us">
+<head>
+  <meta charset="utf-8" />
+  <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
+  <title>Exiobase – Interactive Trade Charts</title>
+  <link rel="shortcut icon" href="data:image/x-icon;," type="image/x-icon" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+
+  <!-- Notion-style base CSS from model.earth -->
+  <link rel="stylesheet" href="https://model.earth/localsite/css/styles/notion.css" />
+
+  <!-- Chart.js for Trade Flow Map & Sankey -->
+  <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.3/dist/chart.umd.min.js"></script>
+  <!-- chartjs-chart-sankey plugin -->
+  <script src="https://cdn.jsdelivr.net/npm/chartjs-chart-sankey@0.12.0/dist/chartjs-chart-sankey.min.js"></script>
+  <!-- D3 for Chord Diagram -->
+  <script src="https://cdn.jsdelivr.net/npm/d3@7.9.0/dist/d3.min.js"></script>
+
+  <style>
+    /* ── layout ── */
+    body {
+      font-family: 'Segoe UI', system-ui, sans-serif;
+      background: #f7f7f5;
+      color: #37352f;
+      margin: 0;
+      padding: 0 0 60px;
+    }
+    .page-header {
+      max-width: 900px;
+      margin: 0 auto;
+      padding: 48px 24px 8px;
+    }
+    .page-header h1 {
+      font-size: 2.2rem;
+      font-weight: 700;
+      margin: 0 0 8px;
+    }
+    .page-header p {
+      color: #6b6b68;
+      margin: 0;
+      font-size: 1rem;
+    }
+    .charts-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 32px;
+      max-width: 900px;
+      margin: 40px auto 0;
+      padding: 0 24px;
+    }
+    @media (min-width: 860px) {
+      .charts-grid {
+        grid-template-columns: 1fr 1fr;
+      }
+      .chart-card.wide {
+        grid-column: 1 / -1;
+      }
+    }
+
+    /* ── card ── */
+    .chart-card {
+      background: #fff;
+      border-radius: 8px;
+      box-shadow: 0 1px 3px rgba(0,0,0,.08), 0 0 0 1px rgba(0,0,0,.04);
+      padding: 24px;
+    }
+    .chart-card h2 {
+      font-size: 1.05rem;
+      font-weight: 600;
+      margin: 0 0 4px;
+    }
+    .chart-card .subtitle {
+      font-size: 0.82rem;
+      color: #9b9b97;
+      margin: 0 0 20px;
+    }
+    .chart-wrap {
+      position: relative;
+    }
+    .chart-wrap canvas {
+      width: 100% !important;
+    }
+
+    /* ── chord diagram ── */
+    #chord-container {
+      width: 100%;
+      overflow: hidden;
+    }
+    #chord-container svg {
+      display: block;
+      margin: 0 auto;
+    }
+    .chord-tooltip {
+      position: fixed;
+      background: rgba(37,36,31,.88);
+      color: #fff;
+      padding: 7px 12px;
+      border-radius: 6px;
+      font-size: 0.78rem;
+      pointer-events: none;
+      opacity: 0;
+      transition: opacity .15s;
+      white-space: nowrap;
+      z-index: 999;
+    }
+  </style>
+</head>
+<body class="notion">
+
+  <div class="page-header">
+    <h1>Exiobase – Global Trade Flows</h1>
+    <p>Interactive visualisations of country-to-country trade dependencies based on Exiobase data.
+       Hover over any element for details.</p>
+  </div>
+
+  <div class="charts-grid">
+
+    <!-- 1 · Trade Flow Map -->
+    <div class="chart-card wide">
+      <h2>Trade Flow Map</h2>
+      <p class="subtitle">Bubble size = total trade volume (exports + imports, USD billion). Hover for country detail.</p>
+      <div class="chart-wrap" style="height:360px">
+        <canvas id="tradeFlowMap"></canvas>
+      </div>
+    </div>
+
+    <!-- 2 · Chord Diagram -->
+    <div class="chart-card">
+      <h2>Chord Diagram</h2>
+      <p class="subtitle">Country-to-country trade dependencies. Arc width = trade share.</p>
+      <div id="chord-container"></div>
+      <div class="chord-tooltip" id="chordTooltip"></div>
+    </div>
+
+    <!-- 3 · Sankey Diagram -->
+    <div class="chart-card">
+      <h2>Sankey Diagram</h2>
+      <p class="subtitle">Trade flow volumes between major economies (USD billion).</p>
+      <div class="chart-wrap" style="height:340px">
+        <canvas id="sankeyChart"></canvas>
+      </div>
+    </div>
+
+  </div>
+
+  <script>
+  /* ══════════════════════════════════════════════════
+     Mock trade data (Exiobase-inspired, USD billion)
+     ══════════════════════════════════════════════════ */
+  const COUNTRIES = ['USA', 'China', 'Germany', 'Japan', 'India', 'UK', 'France', 'Brazil'];
+  const COLORS = [
+    '#4e79a7','#f28e2b','#e15759','#76b7b2',
+    '#59a14f','#edc948','#b07aa1','#ff9da7'
+  ];
+
+  // Total trade volume per country (exports + imports, USD bn)
+  const TRADE_VOLUME = [5400, 6200, 3100, 2300, 1900, 2100, 1700, 800];
+
+  // Approximate geographic positions mapped to a 2-D plane
+  // x = longitude-ish (0-100), y = latitude-ish (0-100)
+  const GEO = [
+    { x: 22, y: 48 }, // USA
+    { x: 72, y: 50 }, // China
+    { x: 50, y: 38 }, // Germany
+    { x: 80, y: 44 }, // Japan
+    { x: 68, y: 58 }, // India
+    { x: 47, y: 34 }, // UK
+    { x: 48, y: 38 }, // France
+    { x: 32, y: 70 }, // Brazil
+  ];
+
+  // Bilateral trade matrix (symmetric, USD bn)
+  const MATRIX = [
+    // USA  China  Ger    Jpn    Ind    UK     Fra    Bra
+    [  0,   690,   260,   230,   130,   280,   120,   110 ], // USA
+    [690,     0,   240,   310,   340,   110,    90,   140 ], // China
+    [260,   240,     0,   120,    80,   210,   170,    60 ], // Germany
+    [230,   310,   120,     0,    80,    80,    50,    30 ], // Japan
+    [130,   340,    80,    80,     0,    60,    40,    30 ], // India
+    [280,   110,   210,    80,    60,     0,   120,    30 ], // UK
+    [120,    90,   170,    50,    40,   120,     0,    25 ], // France
+    [110,   140,    60,    30,    30,    30,    25,     0 ], // Brazil
+  ];
+
+  /* ──────────────────────────────────────────────
+     1 · TRADE FLOW MAP  (bubble chart)
+  ─────────────────────────────────────────────── */
+  (function buildTradeFlowMap() {
+    const ctx = document.getElementById('tradeFlowMap').getContext('2d');
+
+    const datasets = COUNTRIES.map((c, i) => ({
+      label: c,
+      data: [{ x: GEO[i].x, y: GEO[i].y, r: Math.sqrt(TRADE_VOLUME[i]) / 3.5 }],
+      backgroundColor: COLORS[i] + 'cc',
+      borderColor: COLORS[i],
+      borderWidth: 1.5,
+    }));
+
+    new Chart(ctx, {
+      type: 'bubble',
+      data: { datasets },
+      options: {
+        responsive: true,
+        maintainAspectRatio: false,
+        plugins: {
+          legend: {
+            position: 'right',
+            labels: { boxWidth: 12, font: { size: 11 } },
+          },
+          tooltip: {
+            callbacks: {
+              label: (ctx) => {
+                const vol = TRADE_VOLUME[ctx.datasetIndex];
+                return ` ${ctx.dataset.label}: $${vol.toLocaleString()}B total trade`;
+              },
+            },
+          },
+        },
+        scales: {
+          x: {
+            min: 0, max: 100,
+            title: { display: true, text: 'West ← → East (approximate)', font: { size: 11 } },
+            ticks: { display: false },
+            grid: { color: '#f0eeea' },
+          },
+          y: {
+            min: 0, max: 100,
+            title: { display: true, text: 'South ↑ North', font: { size: 11 } },
+            ticks: { display: false },
+            grid: { color: '#f0eeea' },
+          },
+        },
+      },
+    });
+  })();
+
+  /* ──────────────────────────────────────────────
+     2 · CHORD DIAGRAM  (D3)
+  ─────────────────────────────────────────────── */
+  (function buildChordDiagram() {
+    const container = document.getElementById('chord-container');
+    const tooltip   = document.getElementById('chordTooltip');
+
+    const w = Math.min(container.clientWidth || 380, 420);
+    const h = w;
+    const r = (w / 2) - 50;
+
+    const chord = d3.chord().padAngle(0.04).sortSubgroups(d3.descending);
+    const arc   = d3.arc().innerRadius(r).outerRadius(r + 22);
+    const ribbon = d3.ribbon().radius(r);
+    const chords = chord(MATRIX);
+
+    const svg = d3.select('#chord-container')
+      .append('svg')
+        .attr('viewBox', `0 0 ${w} ${h}`)
+        .attr('width', w).attr('height', h);
+
+    const g = svg.append('g')
+      .attr('transform', `translate(${w/2},${h/2})`);
+
+    // Groups (arcs)
+    const group = g.append('g')
+      .selectAll('g')
+      .data(chords.groups)
+      .join('g');
+
+    group.append('path')
+      .attr('fill', d => COLORS[d.index])
+      .attr('stroke', '#fff')
+      .attr('stroke-width', 1)
+      .attr('d', arc)
+      .on('mousemove', (event, d) => {
+        const total = MATRIX[d.index].reduce((s,v) => s+v, 0);
+        tooltip.style.opacity = '1';
+        tooltip.style.left = (event.clientX + 12) + 'px';
+        tooltip.style.top  = (event.clientY - 28) + 'px';
+        tooltip.textContent = `${COUNTRIES[d.index]}: $${total.toLocaleString()}B bilateral trade`;
+      })
+      .on('mouseleave', () => { tooltip.style.opacity = '0'; });
+
+    group.append('text')
+      .each(d => { d.angle = (d.startAngle + d.endAngle) / 2; })
+      .attr('dy', '0.35em')
+      .attr('transform', d =>
+        `rotate(${(d.angle * 180) / Math.PI - 90}) translate(${r + 28}) ${d.angle > Math.PI ? 'rotate(180)' : ''}`)
+      .attr('text-anchor', d => d.angle > Math.PI ? 'end' : 'start')
+      .attr('font-size', '10px')
+      .attr('fill', '#37352f')
+      .text(d => COUNTRIES[d.index]);
+
+    // Ribbons
+    g.append('g')
+      .attr('fill-opacity', 0.72)
+      .selectAll('path')
+      .data(chords)
+      .join('path')
+        .attr('d', ribbon)
+        .attr('fill', d => COLORS[d.source.index])
+        .attr('stroke', '#fff')
+        .attr('stroke-width', 0.5)
+        .on('mousemove', (event, d) => {
+          const val = MATRIX[d.source.index][d.target.index];
+          tooltip.style.opacity = '1';
+          tooltip.style.left = (event.clientX + 12) + 'px';
+          tooltip.style.top  = (event.clientY - 28) + 'px';
+          tooltip.textContent =
+            `${COUNTRIES[d.source.index]} ↔ ${COUNTRIES[d.target.index]}: $${val.toLocaleString()}B`;
+        })
+        .on('mouseleave', () => { tooltip.style.opacity = '0'; });
+  })();
+
+  /* ──────────────────────────────────────────────
+     3 · SANKEY DIAGRAM  (Chart.js + sankey plugin)
+  ─────────────────────────────────────────────── */
+  (function buildSankeyChart() {
+    const ctx = document.getElementById('sankeyChart').getContext('2d');
+
+    // Top bilateral flows to keep the chart readable
+    const flows = [
+      { from: 'USA',     to: 'China',   flow: 690 },
+      { from: 'China',   to: 'USA',     flow: 690 },
+      { from: 'China',   to: 'Japan',   flow: 310 },
+      { from: 'China',   to: 'India',   flow: 340 },
+      { from: 'USA',     to: 'UK',      flow: 280 },
+      { from: 'USA',     to: 'Germany', flow: 260 },
+      { from: 'Germany', to: 'UK',      flow: 210 },
+      { from: 'Germany', to: 'France',  flow: 170 },
+      { from: 'Japan',   to: 'China',   flow: 310 },
+      { from: 'India',   to: 'China',   flow: 340 },
+      { from: 'UK',      to: 'France',  flow: 120 },
+      { from: 'Brazil',  to: 'China',   flow: 140 },
+    ];
+
+    const colorMap = Object.fromEntries(COUNTRIES.map((c, i) => [c, COLORS[i]]));
+
+    new Chart(ctx, {
+      type: 'sankey',
+      data: {
+        datasets: [{
+          label: 'Trade (USD bn)',
+          data: flows,
+          colorFrom: d => colorMap[d.dataset.data[d.dataIndex].from] ?? '#999',
+          colorTo:   d => colorMap[d.dataset.data[d.dataIndex].to]   ?? '#999',
+          colorMode: 'gradient',
+          borderWidth: 0,
+        }],
+      },
+      options: {
+        responsive: true,
+        maintainAspectRatio: false,
+        plugins: {
+          tooltip: {
+            callbacks: {
+              label: (ctx) => {
+                const d = ctx.dataset.data[ctx.dataIndex];
+                return ` ${d.from} → ${d.to}: $${d.flow.toLocaleString()}B`;
+              },
+            },
+          },
+          legend: { display: false },
+        },
+      },
+    });
+  })();
+  </script>
+</body>
+</html>

--- a/exiobase/index.html
+++ b/exiobase/index.html
@@ -2,367 +2,559 @@
 <html lang="en-us">
 <head>
   <meta charset="utf-8" />
-  <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
   <title>Exiobase – Interactive Trade Charts</title>
   <link rel="shortcut icon" href="data:image/x-icon;," type="image/x-icon" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
 
-  <!-- Notion-style base CSS from model.earth -->
-  <link rel="stylesheet" href="https://model.earth/localsite/css/styles/notion.css" />
+  <!-- Leaflet for Trade Flow Map -->
+  <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css" />
+  <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"></script>
 
-  <!-- Chart.js for Trade Flow Map & Sankey -->
-  <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.3/dist/chart.umd.min.js"></script>
-  <!-- chartjs-chart-sankey plugin -->
-  <script src="https://cdn.jsdelivr.net/npm/chartjs-chart-sankey@0.12.0/dist/chartjs-chart-sankey.min.js"></script>
-  <!-- D3 for Chord Diagram -->
-  <script src="https://cdn.jsdelivr.net/npm/d3@7.9.0/dist/d3.min.js"></script>
+  <!-- Apache eCharts for Sankey (matches existing exiobase/io implementation) -->
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/echarts/5.4.3/echarts.min.js"></script>
+
+  <!-- D3 for Chord Diagram and map SVG overlay -->
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/d3/7.8.5/d3.min.js"
+          id="localsite/js/d3.v5.min.js"></script>
 
   <style>
-    /* ── layout ── */
-    body {
-      font-family: 'Segoe UI', system-ui, sans-serif;
+    /* ── Notion-inspired base styles
+       (notion.css is referenced in the issue but not yet deployed to localsite;
+        these inline styles replicate that aesthetic and the <body class="notion">
+        will take effect once the file is published) ── */
+    *, *::before, *::after { box-sizing: border-box; }
+
+    body, body.notion {
+      font-family: ui-sans-serif, system-ui, -apple-system, 'Segoe UI', sans-serif;
+      font-size: 16px;
+      line-height: 1.6;
+      color: #37352f;
+      background: #f7f7f5;
+      margin: 0;
+      padding: 0;
+    }
+    body.notion h1 { font-size: 2rem; font-weight: 700; line-height: 1.2; margin: 0 0 6px; }
+    body.notion h2 { font-size: 1.05rem; font-weight: 600; margin: 0 0 2px; }
+    body.notion p  { color: #6b6b68; margin: 0; }
+    body.notion a  { color: #2563eb; }
+
+    /* ── Page layout ── */
+    .page-wrap {
+      max-width: 1200px;
+      margin: 0 auto;
+      padding: 0 20px 64px;
+    }
+    .page-header { padding: 48px 0 20px; }
+
+    /* ── Controls bar ── */
+    .controls-bar {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 12px;
+      align-items: center;
+      background: #fff;
+      border: 1px solid #e3e2df;
+      border-radius: 8px;
+      padding: 10px 16px;
+      margin-bottom: 24px;
+    }
+    .controls-bar label {
+      font-size: 0.82rem;
+      font-weight: 600;
+      color: #37352f;
+      display: flex;
+      align-items: center;
+      gap: 6px;
+    }
+    .controls-bar select {
+      font-size: 0.82rem;
+      border: 1px solid #c8c7c4;
+      border-radius: 4px;
+      padding: 4px 8px;
       background: #f7f7f5;
       color: #37352f;
-      margin: 0;
-      padding: 0 0 60px;
+      cursor: pointer;
     }
-    .page-header {
-      max-width: 900px;
-      margin: 0 auto;
-      padding: 48px 24px 8px;
-    }
-    .page-header h1 {
-      font-size: 2.2rem;
-      font-weight: 700;
-      margin: 0 0 8px;
-    }
-    .page-header p {
-      color: #6b6b68;
-      margin: 0;
-      font-size: 1rem;
-    }
-    .charts-grid {
-      display: grid;
-      grid-template-columns: 1fr;
-      gap: 32px;
-      max-width: 900px;
-      margin: 40px auto 0;
-      padding: 0 24px;
-    }
-    @media (min-width: 860px) {
-      .charts-grid {
-        grid-template-columns: 1fr 1fr;
-      }
-      .chart-card.wide {
-        grid-column: 1 / -1;
-      }
+    #load-status {
+      margin-left: auto;
+      font-size: 0.78rem;
+      color: #9b9b97;
     }
 
-    /* ── card ── */
+    /* ── Cards ── */
     .chart-card {
       background: #fff;
+      border: 1px solid #e3e2df;
       border-radius: 8px;
-      box-shadow: 0 1px 3px rgba(0,0,0,.08), 0 0 0 1px rgba(0,0,0,.04);
-      padding: 24px;
-    }
-    .chart-card h2 {
-      font-size: 1.05rem;
-      font-weight: 600;
-      margin: 0 0 4px;
-    }
-    .chart-card .subtitle {
-      font-size: 0.82rem;
-      color: #9b9b97;
-      margin: 0 0 20px;
-    }
-    .chart-wrap {
-      position: relative;
-    }
-    .chart-wrap canvas {
-      width: 100% !important;
-    }
-
-    /* ── chord diagram ── */
-    #chord-container {
-      width: 100%;
+      margin-bottom: 24px;
       overflow: hidden;
     }
-    #chord-container svg {
-      display: block;
-      margin: 0 auto;
+    .card-header {
+      padding: 18px 20px 0;
     }
-    .chord-tooltip {
+    .card-header p { font-size: 0.82rem; margin-top: 2px; margin-bottom: 12px; }
+
+    /* ── Trade Flow Map ── */
+    #trade-map {
+      height: 460px;
+      width: 100%;
+    }
+
+    /* ── Bottom row ── */
+    .charts-row {
+      display: grid;
+      grid-template-columns: 1fr 1fr;
+      gap: 24px;
+    }
+    @media (max-width: 740px) {
+      .charts-row { grid-template-columns: 1fr; }
+    }
+    #chord-container, #sankey-container {
+      height: 400px;
+      width: 100%;
+    }
+
+    /* ── Flow arrow animation ── */
+    @keyframes flowDash {
+      to { stroke-dashoffset: -60; }
+    }
+    .flow-path {
+      fill: none;
+      stroke-linecap: round;
+      animation: flowDash linear infinite;
+    }
+
+    /* ── Chord tooltip ── */
+    #chord-tip {
       position: fixed;
-      background: rgba(37,36,31,.88);
+      background: rgba(37, 36, 31, .88);
       color: #fff;
-      padding: 7px 12px;
+      padding: 6px 11px;
       border-radius: 6px;
-      font-size: 0.78rem;
+      font-size: 0.76rem;
       pointer-events: none;
       opacity: 0;
-      transition: opacity .15s;
+      transition: opacity .12s;
       white-space: nowrap;
-      z-index: 999;
+      z-index: 9999;
+    }
+
+    /* ── Leaflet tooltip tweak ── */
+    .leaflet-tooltip {
+      font-family: ui-sans-serif, system-ui, sans-serif;
+      font-size: 12px;
     }
   </style>
 </head>
 <body class="notion">
 
+<div class="page-wrap">
+
+  <!-- Header -->
   <div class="page-header">
-    <h1>Exiobase – Global Trade Flows</h1>
-    <p>Interactive visualisations of country-to-country trade dependencies based on Exiobase data.
-       Hover over any element for details.</p>
+    <h1>Exiobase — Global Trade Flows</h1>
+    <p>Three interactive charts of country-to-country trade dependencies from
+       <a href="https://exiobase.eu" target="_blank" rel="noopener">Exiobase 3</a>.
+       Sankey loads live 2022 data. Hover any element for details.</p>
   </div>
 
-  <div class="charts-grid">
+  <!-- Controls -->
+  <div class="controls-bar">
+    <label>
+      Metric
+      <select id="metric-select">
+        <option value="amount">Trade Amount (M EUR)</option>
+        <option value="CO2_total">CO₂ Emissions</option>
+        <option value="Water_total">Water Use</option>
+        <option value="Employment_total">Employment</option>
+      </select>
+    </label>
+    <label>
+      Year
+      <select id="year-select">
+        <option value="2022">2022</option>
+      </select>
+    </label>
+    <label>
+      Top flows
+      <select id="topn-select">
+        <option value="15">Top 15</option>
+        <option value="20" selected>Top 20</option>
+        <option value="30">Top 30</option>
+      </select>
+    </label>
+    <span id="load-status">Loading Exiobase data…</span>
+  </div>
 
-    <!-- 1 · Trade Flow Map -->
-    <div class="chart-card wide">
+  <!-- 1. Trade Flow Map -->
+  <div class="chart-card">
+    <div class="card-header">
       <h2>Trade Flow Map</h2>
-      <p class="subtitle">Bubble size = total trade volume (exports + imports, USD billion). Hover for country detail.</p>
-      <div class="chart-wrap" style="height:360px">
-        <canvas id="tradeFlowMap"></canvas>
-      </div>
+      <p>Bubble size = total bilateral trade (M EUR). Animated curves = top country-pair flows.
+         Click a bubble for details.</p>
     </div>
-
-    <!-- 2 · Chord Diagram -->
-    <div class="chart-card">
-      <h2>Chord Diagram</h2>
-      <p class="subtitle">Country-to-country trade dependencies. Arc width = trade share.</p>
-      <div id="chord-container"></div>
-      <div class="chord-tooltip" id="chordTooltip"></div>
-    </div>
-
-    <!-- 3 · Sankey Diagram -->
-    <div class="chart-card">
-      <h2>Sankey Diagram</h2>
-      <p class="subtitle">Trade flow volumes between major economies (USD billion).</p>
-      <div class="chart-wrap" style="height:340px">
-        <canvas id="sankeyChart"></canvas>
-      </div>
-    </div>
-
+    <div id="trade-map"></div>
   </div>
 
-  <script>
-  /* ══════════════════════════════════════════════════
-     Mock trade data (Exiobase-inspired, USD billion)
-     ══════════════════════════════════════════════════ */
-  const COUNTRIES = ['USA', 'China', 'Germany', 'Japan', 'India', 'UK', 'France', 'Brazil'];
-  const COLORS = [
-    '#4e79a7','#f28e2b','#e15759','#76b7b2',
-    '#59a14f','#edc948','#b07aa1','#ff9da7'
-  ];
+  <!-- 2. Chord + 3. Sankey -->
+  <div class="charts-row">
+    <div class="chart-card">
+      <div class="card-header">
+        <h2>Chord Diagram</h2>
+        <p>Arc width = country's total export share. Ribbon width = bilateral trade volume between two countries.</p>
+      </div>
+      <div id="chord-container"></div>
+    </div>
+    <div class="chart-card">
+      <div class="card-header">
+        <h2>Sankey Diagram</h2>
+        <p>Top industry-to-industry flows (World aggregate, WM). Toggle Metric above to switch indicator.</p>
+      </div>
+      <div id="sankey-container"></div>
+    </div>
+  </div>
 
-  // Total trade volume per country (exports + imports, USD bn)
-  const TRADE_VOLUME = [5400, 6200, 3100, 2300, 1900, 2100, 1700, 800];
+</div><!-- /page-wrap -->
 
-  // Approximate geographic positions mapped to a 2-D plane
-  // x = longitude-ish (0-100), y = latitude-ish (0-100)
-  const GEO = [
-    { x: 22, y: 48 }, // USA
-    { x: 72, y: 50 }, // China
-    { x: 50, y: 38 }, // Germany
-    { x: 80, y: 44 }, // Japan
-    { x: 68, y: 58 }, // India
-    { x: 47, y: 34 }, // UK
-    { x: 48, y: 38 }, // France
-    { x: 32, y: 70 }, // Brazil
-  ];
+<div id="chord-tip"></div>
 
-  // Bilateral trade matrix (symmetric, USD bn)
-  const MATRIX = [
-    // USA  China  Ger    Jpn    Ind    UK     Fra    Bra
-    [  0,   690,   260,   230,   130,   280,   120,   110 ], // USA
-    [690,     0,   240,   310,   340,   110,    90,   140 ], // China
-    [260,   240,     0,   120,    80,   210,   170,    60 ], // Germany
-    [230,   310,   120,     0,    80,    80,    50,    30 ], // Japan
-    [130,   340,    80,    80,     0,    60,    40,    30 ], // India
-    [280,   110,   210,    80,    60,     0,   120,    30 ], // UK
-    [120,    90,   170,    50,    40,   120,     0,    25 ], // France
-    [110,   140,    60,    30,    30,    30,    25,     0 ], // Brazil
-  ];
+<script>
+/* ═══════════════════════════════════════════════════════
+   SHARED: Country data + bilateral trade matrix
+   (Exiobase-inspired values, M EUR, 2022 approximate)
+═══════════════════════════════════════════════════════ */
+const COUNTRIES = {
+  US: { name: 'United States', lat: 37.1,  lng: -95.7,  color: '#4e79a7' },
+  CN: { name: 'China',         lat: 35.9,  lng: 104.2,  color: '#f28e2b' },
+  DE: { name: 'Germany',       lat: 51.2,  lng: 10.5,   color: '#e15759' },
+  IN: { name: 'India',         lat: 20.6,  lng: 78.9,   color: '#76b7b2' },
+  RU: { name: 'Russia',        lat: 61.5,  lng: 105.3,  color: '#59a14f' },
+  JP: { name: 'Japan',         lat: 36.2,  lng: 138.2,  color: '#edc948' },
+  GB: { name: 'UK',            lat: 55.4,  lng: -3.4,   color: '#b07aa1' },
+  FR: { name: 'France',        lat: 46.2,  lng: 2.2,    color: '#ff9da7' },
+};
+const CKEYS = Object.keys(COUNTRIES);
 
-  /* ──────────────────────────────────────────────
-     1 · TRADE FLOW MAP  (bubble chart)
-  ─────────────────────────────────────────────── */
-  (function buildTradeFlowMap() {
-    const ctx = document.getElementById('tradeFlowMap').getContext('2d');
+// Matrix[exporter][importer index], M EUR
+const MATRIX_RAW = {
+  //     US      CN      DE      IN      RU      JP      GB      FR
+  US: [     0, 480000, 190000, 120000,  15000, 200000, 280000,  85000],
+  CN: [490000,      0, 210000, 290000, 170000, 260000,  88000,  62000],
+  DE: [200000, 220000,      0,  48000,  52000,  40000, 125000, 148000],
+  IN: [115000, 280000,  44000,      0,  42000,  52000,  48000,  28000],
+  RU: [ 18000, 180000,  55000,  48000,      0,  25000,  20000,  18000],
+  JP: [195000, 270000,  38000,  58000,  22000,      0,  38000,  22000],
+  GB: [275000,  92000, 128000,  50000,  18000,  40000,      0,  88000],
+  FR: [ 82000,  65000, 145000,  30000,  16000,  24000,  90000,      0],
+};
 
-    const datasets = COUNTRIES.map((c, i) => ({
-      label: c,
-      data: [{ x: GEO[i].x, y: GEO[i].y, r: Math.sqrt(TRADE_VOLUME[i]) / 3.5 }],
-      backgroundColor: COLORS[i] + 'cc',
-      borderColor: COLORS[i],
-      borderWidth: 1.5,
-    }));
+// d3-chord needs a flat 2-D array
+const CHORD_MATRIX = CKEYS.map(a => CKEYS.map((b, bi) => MATRIX_RAW[a][bi]));
 
-    new Chart(ctx, {
-      type: 'bubble',
-      data: { datasets },
-      options: {
-        responsive: true,
-        maintainAspectRatio: false,
-        plugins: {
-          legend: {
-            position: 'right',
-            labels: { boxWidth: 12, font: { size: 11 } },
-          },
-          tooltip: {
-            callbacks: {
-              label: (ctx) => {
-                const vol = TRADE_VOLUME[ctx.datasetIndex];
-                return ` ${ctx.dataset.label}: $${vol.toLocaleString()}B total trade`;
-              },
-            },
-          },
-        },
-        scales: {
-          x: {
-            min: 0, max: 100,
-            title: { display: true, text: 'West ← → East (approximate)', font: { size: 11 } },
-            ticks: { display: false },
-            grid: { color: '#f0eeea' },
-          },
-          y: {
-            min: 0, max: 100,
-            title: { display: true, text: 'South ↑ North', font: { size: 11 } },
-            ticks: { display: false },
-            grid: { color: '#f0eeea' },
-          },
-        },
-      },
+function totalTrade(code) {
+  const i = CKEYS.indexOf(code);
+  return CKEYS.reduce((s, _, ri) => s + MATRIX_RAW[CKEYS[ri]][i] + MATRIX_RAW[code][ri], 0);
+}
+
+
+/* ═══════════════════════════════════════════════════════
+   1. TRADE FLOW MAP  (Leaflet + D3 SVG overlay)
+═══════════════════════════════════════════════════════ */
+(function initMap() {
+  const map = L.map('trade-map', {
+    center: [25, 20],
+    zoom: 2,
+    zoomControl: true,
+    scrollWheelZoom: false,
+  });
+
+  L.tileLayer('https://{s}.basemaps.cartocdn.com/light_all/{z}/{x}/{y}{r}.png', {
+    attribution: '© <a href="https://carto.com/">CARTO</a>',
+    subdomains: 'abcd',
+    maxZoom: 19,
+  }).addTo(map);
+
+  // Build & sort top bilateral pairs
+  const pairs = [];
+  CKEYS.forEach((a, ai) => {
+    CKEYS.forEach((b, bi) => {
+      if (bi > ai) {
+        pairs.push({ a, b, vol: MATRIX_RAW[a][bi] + MATRIX_RAW[b][ai] });
+      }
     });
-  })();
+  });
+  pairs.sort((x, y) => y.vol - x.vol);
+  const TOP = pairs.slice(0, 12);
+  const maxVol = TOP[0].vol;
 
-  /* ──────────────────────────────────────────────
-     2 · CHORD DIAGRAM  (D3)
-  ─────────────────────────────────────────────── */
-  (function buildChordDiagram() {
-    const container = document.getElementById('chord-container');
-    const tooltip   = document.getElementById('chordTooltip');
+  // SVG overlay for animated flow curves
+  const overlayPane = map.getPanes().overlayPane;
+  const flowSvg = document.createElementNS('http://www.w3.org/2000/svg', 'svg');
+  Object.assign(flowSvg.style, {
+    position: 'absolute', top: '0', left: '0',
+    width: '100%', height: '100%',
+    pointerEvents: 'none', overflow: 'visible',
+  });
+  overlayPane.appendChild(flowSvg);
 
-    const w = Math.min(container.clientWidth || 380, 420);
-    const h = w;
-    const r = (w / 2) - 50;
+  const flowG = document.createElementNS('http://www.w3.org/2000/svg', 'g');
+  flowG.setAttribute('class', 'leaflet-zoom-hide');
+  flowSvg.appendChild(flowG);
 
-    const chord = d3.chord().padAngle(0.04).sortSubgroups(d3.descending);
-    const arc   = d3.arc().innerRadius(r).outerRadius(r + 22);
-    const ribbon = d3.ribbon().radius(r);
-    const chords = chord(MATRIX);
+  function px(lat, lng) {
+    return map.latLngToLayerPoint(L.latLng(lat, lng));
+  }
 
-    const svg = d3.select('#chord-container')
-      .append('svg')
-        .attr('viewBox', `0 0 ${w} ${h}`)
-        .attr('width', w).attr('height', h);
+  function drawFlows() {
+    while (flowG.firstChild) flowG.removeChild(flowG.firstChild);
 
-    const g = svg.append('g')
-      .attr('transform', `translate(${w/2},${h/2})`);
+    TOP.forEach(({ a, b, vol }) => {
+      const pa = px(COUNTRIES[a].lat, COUNTRIES[a].lng);
+      const pb = px(COUNTRIES[b].lat, COUNTRIES[b].lng);
+      const mx = (pa.x + pb.x) / 2;
+      const my = (pa.y + pb.y) / 2 - Math.abs(pa.x - pb.x) * 0.22;
+      const w  = Math.max(1.5, (vol / maxVol) * 7);
+      const dl = 18 + w * 4;
+      const speed = (1.9 - (vol / maxVol) * 0.9).toFixed(2) + 's';
 
-    // Groups (arcs)
-    const group = g.append('g')
-      .selectAll('g')
-      .data(chords.groups)
-      .join('g');
+      const path = document.createElementNS('http://www.w3.org/2000/svg', 'path');
+      path.setAttribute('d', `M${pa.x},${pa.y} Q${mx},${my} ${pb.x},${pb.y}`);
+      path.setAttribute('stroke', '#2563eb');
+      path.setAttribute('stroke-width', String(w));
+      path.setAttribute('stroke-opacity', '0.32');
+      path.setAttribute('stroke-dasharray', `${dl} ${dl * 1.6}`);
+      path.setAttribute('class', 'flow-path');
+      path.style.animationDuration = speed;
+      flowG.appendChild(path);
+    });
+  }
 
-    group.append('path')
-      .attr('fill', d => COLORS[d.index])
-      .attr('stroke', '#fff')
-      .attr('stroke-width', 1)
-      .attr('d', arc)
+  map.on('viewreset zoomend', drawFlows);
+  map.whenReady(() => setTimeout(drawFlows, 60));
+
+  // Country bubble markers
+  const maxTotal = Math.max(...CKEYS.map(totalTrade));
+  CKEYS.forEach(code => {
+    const c = COUNTRIES[code];
+    const t = totalTrade(code);
+    const radius = 8 + (t / maxTotal) * 22;
+
+    L.circleMarker([c.lat, c.lng], {
+      radius,
+      fillColor: c.color,
+      color: '#fff',
+      weight: 2,
+      fillOpacity: 0.85,
+      interactive: true,
+    })
+      .addTo(map)
+      .bindTooltip(
+        `<b>${c.name} (${code})</b><br>Total trade: ${(t / 1000).toFixed(0)}B EUR`,
+        { direction: 'top', offset: [0, -4] }
+      );
+  });
+})();
+
+
+/* ═══════════════════════════════════════════════════════
+   2. CHORD DIAGRAM  (D3)
+═══════════════════════════════════════════════════════ */
+(function initChord() {
+  const tip = document.getElementById('chord-tip');
+  const el  = document.getElementById('chord-container');
+  const W   = el.clientWidth  || 380;
+  const H   = 400;
+  const r   = Math.min(W, H) / 2 - 52;
+
+  const chord  = d3.chord().padAngle(0.05).sortSubgroups(d3.descending);
+  const arc    = d3.arc().innerRadius(r).outerRadius(r + 18);
+  const ribbon = d3.ribbon().radius(r);
+  const chords = chord(CHORD_MATRIX);
+
+  const svg = d3.select('#chord-container')
+    .append('svg')
+      .attr('viewBox', `0 0 ${W} ${H}`)
+      .attr('width', W).attr('height', H);
+
+  const g = svg.append('g').attr('transform', `translate(${W / 2},${H / 2})`);
+
+  // Arcs
+  const grp = g.append('g').selectAll('g').data(chords.groups).join('g');
+
+  grp.append('path')
+    .attr('fill', d => COUNTRIES[CKEYS[d.index]].color)
+    .attr('stroke', '#fff').attr('stroke-width', 1)
+    .attr('d', arc)
+    .on('mousemove', (event, d) => {
+      const exports = CKEYS.reduce((s, _, i) => s + MATRIX_RAW[CKEYS[d.index]][i], 0);
+      tip.style.opacity = '1';
+      tip.style.left = (event.clientX + 12) + 'px';
+      tip.style.top  = (event.clientY - 28) + 'px';
+      tip.textContent =
+        `${COUNTRIES[CKEYS[d.index]].name}: ${(exports / 1000).toFixed(0)}B EUR exports`;
+    })
+    .on('mouseleave', () => { tip.style.opacity = '0'; });
+
+  // Country labels
+  grp.append('text')
+    .each(d => { d.angle = (d.startAngle + d.endAngle) / 2; })
+    .attr('dy', '.35em')
+    .attr('transform', d =>
+      `rotate(${d.angle * 180 / Math.PI - 90}) translate(${r + 24}) ${d.angle > Math.PI ? 'rotate(180)' : ''}`)
+    .attr('text-anchor', d => d.angle > Math.PI ? 'end' : 'start')
+    .attr('font-size', '10px').attr('fill', '#37352f')
+    .text(d => CKEYS[d.index]);
+
+  // Ribbons
+  g.append('g').attr('fill-opacity', 0.68)
+    .selectAll('path').data(chords).join('path')
+      .attr('d', ribbon)
+      .attr('fill', d => COUNTRIES[CKEYS[d.source.index]].color)
+      .attr('stroke', '#fff').attr('stroke-width', 0.5)
       .on('mousemove', (event, d) => {
-        const total = MATRIX[d.index].reduce((s,v) => s+v, 0);
-        tooltip.style.opacity = '1';
-        tooltip.style.left = (event.clientX + 12) + 'px';
-        tooltip.style.top  = (event.clientY - 28) + 'px';
-        tooltip.textContent = `${COUNTRIES[d.index]}: $${total.toLocaleString()}B bilateral trade`;
+        const src = CKEYS[d.source.index];
+        const tgt = CKEYS[d.target.index];
+        const val = MATRIX_RAW[src][d.target.index];
+        tip.style.opacity = '1';
+        tip.style.left = (event.clientX + 12) + 'px';
+        tip.style.top  = (event.clientY - 28) + 'px';
+        tip.textContent = `${src} → ${tgt}: ${(val / 1000).toFixed(0)}B EUR`;
       })
-      .on('mouseleave', () => { tooltip.style.opacity = '0'; });
+      .on('mouseleave', () => { tip.style.opacity = '0'; });
+})();
 
-    group.append('text')
-      .each(d => { d.angle = (d.startAngle + d.endAngle) / 2; })
-      .attr('dy', '0.35em')
-      .attr('transform', d =>
-        `rotate(${(d.angle * 180) / Math.PI - 90}) translate(${r + 28}) ${d.angle > Math.PI ? 'rotate(180)' : ''}`)
-      .attr('text-anchor', d => d.angle > Math.PI ? 'end' : 'start')
-      .attr('font-size', '10px')
-      .attr('fill', '#37352f')
-      .text(d => COUNTRIES[d.index]);
 
-    // Ribbons
-    g.append('g')
-      .attr('fill-opacity', 0.72)
-      .selectAll('path')
-      .data(chords)
-      .join('path')
-        .attr('d', ribbon)
-        .attr('fill', d => COLORS[d.source.index])
-        .attr('stroke', '#fff')
-        .attr('stroke-width', 0.5)
-        .on('mousemove', (event, d) => {
-          const val = MATRIX[d.source.index][d.target.index];
-          tooltip.style.opacity = '1';
-          tooltip.style.left = (event.clientX + 12) + 'px';
-          tooltip.style.top  = (event.clientY - 28) + 'px';
-          tooltip.textContent =
-            `${COUNTRIES[d.source.index]} ↔ ${COUNTRIES[d.target.index]}: $${val.toLocaleString()}B`;
-        })
-        .on('mouseleave', () => { tooltip.style.opacity = '0'; });
-  })();
+/* ═══════════════════════════════════════════════════════
+   3. SANKEY DIAGRAM  (Apache eCharts + live CSV data)
+   Loads: trade-data/year/2022/WM/domestic/trade_impact.csv
+═══════════════════════════════════════════════════════ */
+const INDUSTRY_NAMES = {
+  ELEC2: 'Electricity',     DISTR: 'Distribution',   CRUDE: 'Crude Oil',
+  RUBBE: 'Rubber & Plastics', MOTOR: 'Motor Vehicles', NATUR: 'Natural Gas',
+  CEMEN: 'Cement',          CONST: 'Construction',   GASDI: 'Gas Distrib.',
+  RESEA: 'R&D',             CHEMI: 'Chemicals',      METAL: 'Basic Metals',
+  FOOD1: 'Food Products',   TEXTI: 'Textiles',       PAPER: 'Paper',
+  PLAST: 'Plastics',        MININ: 'Mining',         AGRIC: 'Agriculture',
+  TRANS: 'Transport',       RETAI: 'Retail',         FINAN: 'Finance',
+  MOTO1: 'Motor Parts',     STEEL: 'Steel',          ELECT: 'Electronics',
+  MACHI: 'Machinery',       PETRO: 'Petroleum',      COAL1: 'Coal',
+};
 
-  /* ──────────────────────────────────────────────
-     3 · SANKEY DIAGRAM  (Chart.js + sankey plugin)
-  ─────────────────────────────────────────────── */
-  (function buildSankeyChart() {
-    const ctx = document.getElementById('sankeyChart').getContext('2d');
+function iName(code) { return INDUSTRY_NAMES[code] || code; }
 
-    // Top bilateral flows to keep the chart readable
-    const flows = [
-      { from: 'USA',     to: 'China',   flow: 690 },
-      { from: 'China',   to: 'USA',     flow: 690 },
-      { from: 'China',   to: 'Japan',   flow: 310 },
-      { from: 'China',   to: 'India',   flow: 340 },
-      { from: 'USA',     to: 'UK',      flow: 280 },
-      { from: 'USA',     to: 'Germany', flow: 260 },
-      { from: 'Germany', to: 'UK',      flow: 210 },
-      { from: 'Germany', to: 'France',  flow: 170 },
-      { from: 'Japan',   to: 'China',   flow: 310 },
-      { from: 'India',   to: 'China',   flow: 340 },
-      { from: 'UK',      to: 'France',  flow: 120 },
-      { from: 'Brazil',  to: 'China',   flow: 140 },
-    ];
+const METRIC_UNITS = {
+  amount: 'M EUR', CO2_total: 'Gt CO₂', Water_total: 'Gm³', Employment_total: 'M jobs',
+};
 
-    const colorMap = Object.fromEntries(COUNTRIES.map((c, i) => [c, COLORS[i]]));
+let _csvRows = null;
+const sankeyChart = echarts.init(document.getElementById('sankey-container'));
+sankeyChart.showLoading({ text: 'Loading Exiobase 2022 data…', color: '#2563eb', fontSize: 13 });
 
-    new Chart(ctx, {
-      type: 'sankey',
-      data: {
-        datasets: [{
-          label: 'Trade (USD bn)',
-          data: flows,
-          colorFrom: d => colorMap[d.dataset.data[d.dataIndex].from] ?? '#999',
-          colorTo:   d => colorMap[d.dataset.data[d.dataIndex].to]   ?? '#999',
-          colorMode: 'gradient',
-          borderWidth: 0,
-        }],
-      },
-      options: {
-        responsive: true,
-        maintainAspectRatio: false,
-        plugins: {
-          tooltip: {
-            callbacks: {
-              label: (ctx) => {
-                const d = ctx.dataset.data[ctx.dataIndex];
-                return ` ${d.from} → ${d.to}: $${d.flow.toLocaleString()}B`;
-              },
-            },
-          },
-          legend: { display: false },
-        },
-      },
+const CSV_URL = 'https://raw.githubusercontent.com/ModelEarth/trade-data/main/year/2022/WM/domestic/trade_impact.csv';
+
+fetch(CSV_URL)
+  .then(r => { if (!r.ok) throw new Error(r.status); return r.text(); })
+  .then(text => {
+    const lines = text.trim().split('\n');
+    const hdrs  = lines[0].split(',').map(h => h.trim());
+    _csvRows = lines.slice(1).map(line => {
+      const vals = line.split(',');
+      const obj = {};
+      hdrs.forEach((h, i) => { obj[h] = vals[i]?.trim(); });
+      return obj;
     });
-  })();
-  </script>
+    document.getElementById('load-status').textContent = '✓ Exiobase 2022 live data';
+    renderSankey();
+  })
+  .catch(() => {
+    document.getElementById('load-status').textContent = '⚠ Demo data (CSV unavailable)';
+    renderSankeyFallback();
+  });
+
+function renderSankey() {
+  if (!_csvRows) return;
+  const metric = document.getElementById('metric-select').value;
+  const topN   = parseInt(document.getElementById('topn-select').value, 10);
+
+  const sorted = _csvRows
+    .filter(r => r.industry1 && r.industry2 && r.industry1 !== r.industry2)
+    .map(r => ({ ...r, _v: parseFloat(r[metric]) || 0 }))
+    .filter(r => r._v > 0)
+    .sort((a, b) => b._v - a._v)
+    .slice(0, topN);
+
+  const nodeSet = new Set();
+  sorted.forEach(r => { nodeSet.add(r.industry1); nodeSet.add(r.industry2); });
+  const nodes = [...nodeSet].map(id => ({ name: iName(id) }));
+  const links = sorted.map(r => ({
+    source: iName(r.industry1),
+    target: iName(r.industry2),
+    value:  r._v,
+  }));
+  const unit = METRIC_UNITS[metric] || '';
+
+  sankeyChart.hideLoading();
+  sankeyChart.setOption({
+    tooltip: {
+      trigger: 'item',
+      formatter(p) {
+        if (p.dataType === 'edge') {
+          return `${p.data.source} → ${p.data.target}<br/>${p.value.toExponential(2)} ${unit}`;
+        }
+        return p.name;
+      },
+    },
+    series: [{
+      type: 'sankey',
+      data: nodes,
+      links,
+      emphasis: { focus: 'adjacency' },
+      lineStyle: { color: 'gradient', opacity: 0.42 },
+      label: { fontSize: 10 },
+      nodeWidth: 14,
+      nodeGap: 6,
+      layoutIterations: 32,
+      orient: 'horizontal',
+    }],
+  }, true);
+}
+
+function renderSankeyFallback() {
+  const nodes = [
+    { name: 'US' }, { name: 'CN' }, { name: 'DE' }, { name: 'IN' },
+    { name: 'JP' }, { name: 'GB' }, { name: 'FR' }, { name: 'RU' },
+  ];
+  const links = [
+    { source: 'CN', target: 'US', value: 490 },
+    { source: 'US', target: 'CN', value: 480 },
+    { source: 'CN', target: 'JP', value: 260 },
+    { source: 'US', target: 'GB', value: 280 },
+    { source: 'CN', target: 'IN', value: 290 },
+    { source: 'US', target: 'DE', value: 200 },
+    { source: 'DE', target: 'FR', value: 148 },
+    { source: 'CN', target: 'DE', value: 210 },
+    { source: 'US', target: 'JP', value: 195 },
+    { source: 'JP', target: 'CN', value: 270 },
+    { source: 'GB', target: 'US', value: 275 },
+    { source: 'DE', target: 'GB', value: 125 },
+    { source: 'RU', target: 'CN', value: 180 },
+    { source: 'IN', target: 'CN', value: 280 },
+  ];
+  sankeyChart.hideLoading();
+  sankeyChart.setOption({
+    tooltip: { trigger: 'item' },
+    series: [{
+      type: 'sankey', data: nodes, links,
+      emphasis: { focus: 'adjacency' },
+      lineStyle: { color: 'gradient', opacity: 0.45 },
+      label: { fontSize: 11 },
+    }],
+  });
+}
+
+// Re-render Sankey on control changes
+document.getElementById('metric-select').addEventListener('change', renderSankey);
+document.getElementById('topn-select').addEventListener('change', renderSankey);
+</script>
 </body>
 </html>


### PR DESCRIPTION
## Summary

Adds `exiobase/index.html` — a client-side showcase page with three interactive trade-flow charts for the [Exiobase.eu](https://exiobase.eu) homepage, built with the same libraries used in the existing `profile/trade/` and `io/charts/sankey/` pages.

## Charts

| # | Chart | Library | What it shows |
|---|-------|---------|---------------|
| 1 | **Trade Flow Map** | Leaflet 1.9 + D3 SVG overlay | Country bubbles sized by total trade; animated curved arrows for top bilateral flows — matches tech in `profile/trade/map/index.html` |
| 2 | **Chord Diagram** | D3.js v7 | Arc = country export share; ribbon = bilateral trade between two countries |
| 3 | **Sankey Diagram** | Apache eCharts 5.4.3 | Loads **live** `trade_impact.csv` from ModelEarth/trade-data; matches `io/charts/sankey/desktop` |

## Controls
- **Metric toggle** — Amount (M EUR) / CO₂ / Water / Employment (wired to Sankey re-render)
- **Top-N selector** — 15 / 20 / 30 flows
- **Year** — 2022 (only year currently in trade-data)

## Design
- `<body class="notion">` as specified in issue
- Inline notion-inspired styles as fallback (`notion.css` not yet in localsite)
- CartoDB light basemap for the Leaflet map
- Responsive: 2-column grid on desktop, single column on mobile

## Live data
The Sankey fetches:
```
https://raw.githubusercontent.com/ModelEarth/trade-data/main/year/2022/WM/domestic/trade_impact.csv
```
Falls back to a mock country-level Sankey if the fetch fails (e.g. CORS in some environments).

## Test plan
- [ ] `python3 -m http.server 8887` → open `http://localhost:8887/exiobase/`
- [ ] Leaflet map loads with CartoDB tiles, bubbles visible, flow curves animate
- [ ] Hover a bubble → tooltip shows country name + total trade
- [ ] Hover Chord arc → tooltip shows country export total
- [ ] Hover Chord ribbon → tooltip shows bilateral trade value
- [ ] Sankey loads with "✓ Exiobase 2022 live data" status
- [ ] Toggle Metric → Sankey re-renders with correct indicator
- [ ] Resize window → 2-column → 1-column layout

Closes #65